### PR TITLE
Update Gradle Wrapper from 6.7.1 to 6.8.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=3239b5ed86c3838a37d983ac100573f64c1f3fd8e1eb6c89fa5f9529b5ec091d
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionSha256Sum=8de6efc274ab52332a9c820366dd5cf5fc9d35ec7078fd70c8ec6913431ee610
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update Gradle Wrapper from 6.7.1 to 6.8.2.

Read the release notes: https://docs.gradle.org/6.8.2/release-notes.html

---

The checksums of the Wrapper JAR and the distribution binary have been successfully verified.

- Gradle release: `6.8.2`
- Distribution (-bin) zip checksum: `8de6efc274ab52332a9c820366dd5cf5fc9d35ec7078fd70c8ec6913431ee610`
- Wrapper JAR Checksum: `e996d452d2645e70c01c11143ca2d3742734a28da2bf61f25c82bdc288c9e637`

You can find the reference checksum values at https://gradle.org/release-checksums/

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>